### PR TITLE
Fix chests causing other blocks having wrong lighting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://files.minecraftforge.net/maven"
         }
         maven {
             name = "sonatype"
@@ -11,13 +11,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.1'
     }
 }
 
 apply plugin: 'forge'
 
-version = "1.4b"
+version = "1.4b.1-GTNH"
 group= "wanion.avaritiaddons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Avaritiaddons"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip

--- a/src/main/java/wanion/avaritiaddons/block/chest/compressed/ItemRendererCompressedChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/compressed/ItemRendererCompressedChest.java
@@ -12,6 +12,8 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 import wanion.avaritiaddons.block.chest.RendererAvaritiaddonsChest;
 
 @SideOnly(Side.CLIENT)
@@ -38,5 +40,6 @@ public final class ItemRendererCompressedChest implements IItemRenderer
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityCompressedChest, -0.5F, -0.5F, -0.5F, 0);
 		else
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityCompressedChest, 0, 0, 0, 0);
+		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 	}
 }

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/ItemRendererInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/ItemRendererInfinityChest.java
@@ -12,6 +12,8 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 import wanion.avaritiaddons.block.chest.RendererAvaritiaddonsChest;
 
 @SideOnly(Side.CLIENT)
@@ -38,5 +40,6 @@ public final class ItemRendererInfinityChest implements IItemRenderer
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityInfinityChest, -0.5F, -0.5F, -0.5F, 0);
 		else
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityInfinityChest, 0, 0, 0, 0);
+		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 	}
 }


### PR DESCRIPTION
The item rendering assumes rescale normal to be always on. In our chest renderers this forget to be turned back on, and was causing blocks rendered after a chest to have wrong lighting.