### PR TITLE
fix slot check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.5.1-GTNH"
+version = "1.5.2-GTNH"
 group= "wanion.avaritiaddons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Avaritiaddons"
 

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -39,7 +39,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 			return;
 		if (slot < 243) {
 			final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[slot];
-			if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
+			if (isSameItem(slotStack, itemStack)) {
 				int tmp = itemStack.stackSize;
 				itemStack.stackSize = slotStack.stackSize;
 				slotStack.stackSize = tmp;
@@ -66,11 +66,16 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 		markDirty();
 	}
 
+	private boolean isSameItem(ItemStack slotStack, ItemStack itemStack) {
+		if (slotStack == null || itemStack == null) return false;
+		return slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack);
+	}
+
 	private int findSlotFor(@Nonnull final ItemStack itemStack)
 	{
 		for (int i = 0; i < 243; i++) {
 			final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[i];
-			if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
+			if (isSameItem(slotStack, itemStack)) {
 				if ((long) slotStack.stackSize + (long) itemStack.stackSize <= (long) Integer.MAX_VALUE)
 					return i;
 			}
@@ -133,13 +138,13 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 	@Override
 	public boolean isItemValidForSlot(final int slot, final ItemStack itemStack)
 	{
-		return slot != 243;
+		return slot != 243 || findSlotFor(itemStack) != -1;
 	}
 
 	@Override
 	public final int getSizeInventory()
 	{
-		return 243;
+		return 244;
 	}
 
 	@Override

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -68,7 +68,10 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 
 	private boolean isSameItem(ItemStack slotStack, ItemStack itemStack) {
 		if (slotStack == null || itemStack == null) return false;
-		return slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack);
+		boolean itemEqual = slotStack.getItem() == itemStack.getItem();
+		boolean metaEqual = (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage());
+		boolean tagEqual = ItemStack.areItemStackTagsEqual(itemStack, slotStack);
+		return itemEqual && metaEqual && tagEqual;
 	}
 
 	private int findSlotFor(@Nonnull final ItemStack itemStack)


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8831

@repo-alt the `getSizeInventory()` is set to 244 intentionally, inf chest needs a fake slot to hold the input item temporarily and then merge it with existing items. so maybe you need to add special handler for inf chest in OC