### PR TITLE
Fix empty nbt tags on chests

### DIFF
--- a/src/main/java/wanion/avaritiaddons/block/chest/BlockAvaritiaddonsChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/BlockAvaritiaddonsChest.java
@@ -84,14 +84,14 @@ public abstract class BlockAvaritiaddonsChest extends BlockContainer {
     public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
         TileEntity te = world.getTileEntity(x, y, z);
         Block block = world.getBlock(x, y, z);
-        ArrayList<ItemStack> arr = new ArrayList<>();
+        ArrayList<ItemStack> list = new ArrayList<>();
         if (te instanceof TileEntityAvaritiaddonsChest) {
             TileEntityAvaritiaddonsChest tileEntityAvaritiaddonsChest = (TileEntityAvaritiaddonsChest) te;
             final ItemStack droppedStack = new ItemStack(block, 1, 0);
             droppedStack.setTagCompound(tileEntityAvaritiaddonsChest.writeCustomNBT(new NBTTagCompound()));
-            arr.add(droppedStack);
+            list.add(droppedStack);
         }
-        return arr;
+        return list;
     }
 
 }

--- a/src/main/java/wanion/avaritiaddons/block/chest/RendererAvaritiaddonsChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/RendererAvaritiaddonsChest.java
@@ -21,7 +21,7 @@ public class RendererAvaritiaddonsChest extends TileEntitySpecialRenderer {
 
     public static final RendererAvaritiaddonsChest instance = new RendererAvaritiaddonsChest();
 
-    private ModelChest modelChest = new ModelChest();
+    private final ModelChest modelChest = new ModelChest();
 
     private RendererAvaritiaddonsChest() {}
 

--- a/src/main/java/wanion/avaritiaddons/block/chest/TileEntityAvaritiaddonsChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/TileEntityAvaritiaddonsChest.java
@@ -107,15 +107,18 @@ public abstract class TileEntityAvaritiaddonsChest extends TileEntity implements
 
     public NBTTagCompound writeCustomNBT(final NBTTagCompound nbtTagCompound) {
         final NBTTagList nbtTagList = new NBTTagList();
+        boolean hasItems = false;
         for (int i = 0; i < inventoryAvaritiaddonsChest.getSizeInventory(); i++) {
             final ItemStack itemStack = inventoryAvaritiaddonsChest.getStackInSlot(i);
             if (itemStack != null) {
                 final NBTTagCompound slotCompound = new NBTTagCompound();
                 slotCompound.setShort("Slot", (short) i);
                 nbtTagList.appendTag(itemStack.writeToNBT(slotCompound));
+                hasItems = true;
             }
         }
-        nbtTagCompound.setTag("Contents", nbtTagList);
+        if (hasItems) nbtTagCompound.setTag("Contents", nbtTagList);
+        if (nbtTagCompound.hasNoTags()) return null;
         return nbtTagCompound;
     }
 

--- a/src/main/java/wanion/avaritiaddons/block/chest/compressed/TileEntityCompressedChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/compressed/TileEntityCompressedChest.java
@@ -22,7 +22,7 @@ public final class TileEntityCompressedChest extends TileEntityAvaritiaddonsChes
     }
 
     @Override
-    public final String getInventoryName() {
+    public String getInventoryName() {
         return "container.CompressedChest";
     }
 

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/ContainerInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/ContainerInfinityChest.java
@@ -24,7 +24,6 @@ import wanion.avaritiaddons.network.InfinityChestSlotSync;
 
 public final class ContainerInfinityChest extends ContainerAvaritiaddonsChest {
 
-    @SuppressWarnings("unchecked")
     public ContainerInfinityChest(@Nonnull final TileEntityInfinityChest tileEntityCompressedChest,
             final InventoryPlayer inventoryPlayer) {
         super(tileEntityCompressedChest, inventoryPlayer);
@@ -171,7 +170,6 @@ public final class ContainerInfinityChest extends ContainerAvaritiaddonsChest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     public void syncData(final ItemStack itemStack, final int slot, final int stackSize) {
         if (itemStack != null) {
             itemStack.stackSize = stackSize;

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -25,7 +25,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest 
     }
 
     @Override
-    public final void setInventorySlotContents(int slot, final ItemStack itemStack) {
+    public void setInventorySlotContents(int slot, final ItemStack itemStack) {
         if (itemStack == null) {
             inventoryAvaritiaddonsChest.contents[slot] = null;
             markDirty();
@@ -80,7 +80,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest 
     }
 
     @Override
-    public final void readCustomNBT(final NBTTagCompound nbtTagCompound) {
+    public void readCustomNBT(final NBTTagCompound nbtTagCompound) {
         final NBTTagList nbtTagList = nbtTagCompound.getTagList("Contents", 10);
         for (int i = 0; i < nbtTagList.tagCount(); i++) {
             final NBTTagCompound slotCompound = nbtTagList.getCompoundTagAt(i);
@@ -91,17 +91,20 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest 
     }
 
     @Override
-    public final NBTTagCompound writeCustomNBT(final NBTTagCompound nbtTagCompound) {
+    public NBTTagCompound writeCustomNBT(final NBTTagCompound nbtTagCompound) {
         final NBTTagList nbtTagList = new NBTTagList();
+        boolean hasItems = false;
         for (int i = 0; i < 243; i++) {
             final ItemStack itemStack = inventoryAvaritiaddonsChest.getStackInSlot(i);
             if (itemStack != null) {
                 final NBTTagCompound slotCompound = new NBTTagCompound();
                 slotCompound.setShort("Slot", (short) i);
                 nbtTagList.appendTag(writeItemStackToNbt(slotCompound, itemStack));
+                hasItems = true;
             }
         }
-        nbtTagCompound.setTag("Contents", nbtTagList);
+        if (hasItems) nbtTagCompound.setTag("Contents", nbtTagList);
+        if (nbtTagCompound.hasNoTags()) return null;
         return nbtTagCompound;
     }
 
@@ -131,7 +134,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest 
     }
 
     @Override
-    public final int getSizeInventory() {
+    public int getSizeInventory() {
         return 244;
     }
 
@@ -143,7 +146,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest 
     }
 
     @Override
-    public final String getInventoryName() {
+    public String getInventoryName() {
         return "container.InfinityChest";
     }
 }

--- a/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/ContainerExtremeAutoCrafter.java
+++ b/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/ContainerExtremeAutoCrafter.java
@@ -52,6 +52,7 @@ public class ContainerExtremeAutoCrafter extends Container {
         return itemstack;
     }
 
+    @Override
     public boolean canDragIntoSlot(final Slot slot) {
         return slot.slotNumber < 81 || slot.slotNumber > 162;
     }

--- a/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
+++ b/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
@@ -206,12 +206,14 @@ public class TileEntityExtremeAutoCrafter extends TileEntity implements ISidedIn
 
     public NBTTagCompound writeCustomNBT(final NBTTagCompound nbtTagCompound) {
         final NBTTagList nbtTagList = new NBTTagList();
+        boolean hasItems = false;
         for (int i = 0; i < 162; i++) {
             final ItemStack itemStack = getStackInSlot(i);
             if (itemStack != null) {
                 final NBTTagCompound slotCompound = new NBTTagCompound();
                 slotCompound.setShort("Slot", (short) i);
                 nbtTagList.appendTag(itemStack.writeToNBT(slotCompound));
+                hasItems = true;
             }
         }
         final ItemStack output = getStackInSlot(162);
@@ -219,8 +221,10 @@ public class TileEntityExtremeAutoCrafter extends TileEntity implements ISidedIn
             final NBTTagCompound slotCompound = new NBTTagCompound();
             slotCompound.setShort("Slot", (short) 162);
             nbtTagList.appendTag(output.writeToNBT(slotCompound));
+            hasItems = true;
         }
-        nbtTagCompound.setTag("Contents", nbtTagList);
+        if (hasItems) nbtTagCompound.setTag("Contents", nbtTagList);
+        if (nbtTagCompound.hasNoTags()) return null;
         return nbtTagCompound;
     }
 


### PR DESCRIPTION
When you break an empty compressed chest there is an empty nbt tag that stays attached to it and makes it not stack with freshly crafted empty compressed chests, same thing with infinity chests and dire autocrafting tables

![image](https://github.com/user-attachments/assets/af05fe47-c314-4afd-9b1d-09b218f3c4de)


This pr sets the nbt tag to null if there is no content

Can someone triple check that I got it right, we wouldn't want to accidentally void the contents of infinity / compressed chests xd