### PR TITLE
Allow Dire Autocrafting Table to batchcraft recipes

### DIFF
--- a/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
+++ b/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
@@ -94,7 +94,7 @@ public class TileEntityExtremeAutoCrafter extends TileEntity implements ISidedIn
     private int matches(@Nonnull final TIntIntMap inputMap, @Nonnull final TIntIntMap patternMap) {
         if (inputMap.size() < patternMap.size() || !inputMap.keySet().containsAll(patternMap.keySet())) return 0;
 
-        int amount = 0x7FFFFFFF;
+        int amount = Integer.MAX_VALUE;
         for (final int key : patternMap.keys()) {
             amount = Math.min(amount, inputMap.get(key) / patternMap.get(key));
             if (amount <= 0) return 0;

--- a/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
+++ b/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
@@ -81,22 +81,30 @@ public class TileEntityExtremeAutoCrafter extends TileEntity implements ISidedIn
         if (patternMap == null) return;
         final ItemStack outputStack = itemStacks[162];
         if (outputStack == null || outputStack.stackSize + outputStackSize > outputStack.getMaxStackSize()
-                || !matches(MetaItem.getSmartKeySizeMap(0, 81, itemStacks), patternMap))
+                || outputStackSize == 0)
             return;
-        cleanInput();
-        outputStack.stackSize += outputStackSize;
+        int maxAmount = matches(MetaItem.getSmartKeySizeMap(0, 81, itemStacks), patternMap);
+        maxAmount = Math.min(maxAmount, (outputStack.getMaxStackSize() - outputStack.stackSize) / outputStackSize);
+        if (maxAmount == 0) return;
+        cleanInput(maxAmount);
+        outputStack.stackSize += maxAmount * outputStackSize;
         markDirty();
     }
 
-    private boolean matches(@Nonnull final TIntIntMap inputMap, @Nonnull final TIntIntMap patternMap) {
-        if (inputMap.size() >= patternMap.size() && inputMap.keySet().containsAll(patternMap.keySet())) {
-            for (final int key : patternMap.keys()) if (inputMap.get(key) < patternMap.get(key)) return false;
-            return true;
-        } else return false;
+    private int matches(@Nonnull final TIntIntMap inputMap, @Nonnull final TIntIntMap patternMap) {
+        if (inputMap.size() < patternMap.size() || !inputMap.keySet().containsAll(patternMap.keySet())) return 0;
+
+        int amount = 0x7FFFFFFF;
+        for (final int key : patternMap.keys()) {
+            amount = Math.min(amount, inputMap.get(key) / patternMap.get(key));
+            if (amount <= 0) return 0;
+        }
+        return amount;
     }
 
-    private void cleanInput() {
+    private void cleanInput(int maxAmount) {
         final TIntIntMap patternMap = new TIntIntHashMap(this.patternMap);
+        patternMap.transformValues((v) -> v * maxAmount);
         for (int i = 0; i < 81 && !patternMap.isEmpty(); i++) {
             final ItemStack itemStack = itemStacks[i];
             final int key = MetaItem.get(itemStack);


### PR DESCRIPTION
Every 10 ticks the Dire Autocrafting Table will try to craft as many recipes as possible instead of one at a time. It is still limited by the 81 input slots and the maximum output stack size.

I consider this more of a QoL change instead of a rebalance. Extreme Crafting becomes more important late game with mostly Solar Panels, resulting in players either needing to add several Autocrafting Tables or even WA them, which I think is bad practice and quite awkward to do. I personally don't think natively speeding up the Autocrafting Table makes it too good, just a necessity.

Changes have been tested on Infinity Ingot, EIO Teleporter (output stacksize 9), Magic Memory (non-consumed input) and Cosmic Meatballs (shapeless). Although for non-consumed input items, the parallel is limited by the amount of them in the grid. This is mainly relevant for the Magical Memory using an Extremely Primordial Pearl and is a limitation to how the logic was originally implemented (e.g. 10 primordial pearls in input grid = 10 parallels, none are consumed).