### PR TITLE
Fix dire auto crafting table recipe change detection

### DIFF
--- a/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
+++ b/src/main/java/wanion/avaritiaddons/block/extremeautocrafter/TileEntityExtremeAutoCrafter.java
@@ -50,9 +50,7 @@ public class TileEntityExtremeAutoCrafter extends TileEntity implements ISidedIn
             recipeChanged = false;
             final ItemStack output = ExtremeCraftingManager.getInstance().findMatchingRecipe(craftingMatrix, worldObj);
             final ItemStack slotStack = getStackInSlot(162);
-            if (output != null && slotStack != null
-                    && slotStack.getItem() == output.getItem()
-                    && (!output.getHasSubtypes() || output.getItemDamage() == slotStack.getItemDamage())) {
+            if (output != null && slotStack != null && ItemStack.areItemStacksEqual(output, slotStack)) {
                 patternMap = MetaItem.getKeySizeMap(81, 162, itemStacks);
             } else if (slotStack != null && slotStack.stackSize > 0) {
                 patternMap = null;

--- a/src/main/java/wanion/avaritiaddons/common/slot/SpecialSlot.java
+++ b/src/main/java/wanion/avaritiaddons/common/slot/SpecialSlot.java
@@ -32,8 +32,6 @@ public class SpecialSlot extends Slot {
         final ItemStack slotStack = getStack();
         final ItemStack playerStack = entityPlayer.inventory.getItemStack();
         return slotStack != null && slotStack.stackSize > 0
-                && (playerStack == null || (slotStack.getItem() == playerStack.getItem()
-                        && (!playerStack.getHasSubtypes() || playerStack.getItemDamage() == slotStack.getItemDamage())
-                        && ItemStack.areItemStackTagsEqual(playerStack, slotStack)));
+                && (playerStack == null || ItemStack.areItemStacksEqual(slotStack, playerStack));
     }
 }


### PR DESCRIPTION
Some items have multiple damage values ​​but getHasSubtypes returns false, which doesn't work properly.

fixes:

https://github.com/user-attachments/assets/98c17f12-2136-4c26-8856-b7c53294b242

